### PR TITLE
Add loading div within the BindToStores render

### DIFF
--- a/src/lib/BindToStores.react.js
+++ b/src/lib/BindToStores.react.js
@@ -42,7 +42,14 @@ export default function bindResources(Component, resourceName) {
         this.setState(state);
       },
       render() {
-        return <Component {...this.props} {...this.state}/>
+        return (
+          <div>
+            { this.state.loading ?
+              <div>Loading...</div> :
+              <Component {...this.props} {...this.state} />
+            }
+          </div>
+        )
       }
   })
   return BoundComponent;


### PR DESCRIPTION
NOT READY FOR MERGE

@BJK I have some questions about this that I'd like to discuss with you on Monday:
1. Who owns the spinner image we use in `web-apps`? I didn't want to just take it in case we licensed it;
2. I _think_ the app is set up to process style files given the Webpack config; can you confirm this? How about images?;
3. Honestly this would be a lot cleaner if instead of a ternary it used your new `if`/`else` components. Any plans to put those into a separate library soon so we could use them here?; and,
4. Random small questions: Should `this.state.processing` also be included in the condition used to determine what is displayed? Should there be a parameter that allows a user to choose if the loader is included? Would you prefer that I just create a `Loader` component separate from this file?