### PR TITLE
Blr/bts/container and router context

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,6 +21,7 @@
       "API_HOST": false,
       "API_KEY": false,
       "ASSET_HOST": false,
+      "chai": false,
       "CONTENT_HOST": false,
       "expect": false,
       "NODE_APP_HOST": false,

--- a/src/lib/Container.js
+++ b/src/lib/Container.js
@@ -1,0 +1,17 @@
+class Container {
+  constructor() { this.init() }
+  init() {
+    this.actions = {}
+    this.stores = {}
+  }
+  getAction(name) { return this.actions[name] }
+  getStore(name) { return this.stores[name] }
+  register(type, name, component) {
+    this[type][name] = component
+    return component
+  }
+  registerAction(name, component) { return this.register('actions', name, component) }
+  registerStore(name, component) { return this.register('stores', name, component) }
+}
+
+export default new Container()

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,5 @@ import FUHelpers from '../src/testUtils/ChaiAddons'
 
 chai.use(FUHelpers)
 
-
-var libContext = require.context("./lib/", true, /Spec.js$/);
-libContext.keys().forEach(libContext);
-
+const libContext = require.context('./lib/', true, /Spec.js$/)
+libContext.keys().forEach(libContext)

--- a/test/lib/ContainerSpec.js
+++ b/test/lib/ContainerSpec.js
@@ -1,0 +1,16 @@
+import Container from '../../src/lib/Container'
+
+const store = {store: 'bar'}
+const action = {action: 'bar'}
+
+describe('Container', () => {
+  before(() => {
+    Container.registerAction('foo', action)
+    Container.registerStore('foo', store)
+  })
+  after(() => { Container.init() })
+
+  it('registers an action', () => expect(Container.getAction('foo')).to.equal(action))
+  it('registeres a store', () => expect(Container.getStore('foo')).to.equal(store))
+  it('does not return a blank component', () => expect(Container.getAction('noExisto')).to.not.exist)
+})

--- a/test/support/stubRouterContext.react.js
+++ b/test/support/stubRouterContext.react.js
@@ -2,9 +2,7 @@ import assign from 'object-assign'
 import React from 'react'
 
 export default (Component, props, stubs) => {
-  // function RouterStub() { }
-
-  var RouterStub = assign(
+  const RouterStub = assign(
     {
       createHref() {},
       getCurrentParams () {},
@@ -18,7 +16,7 @@ export default (Component, props, stubs) => {
       push () {},
       replace () {}
     },
-    stubs  // Pass additional empty functions as necessary
+    stubs  // Pass additional empty functions as necessary.
   )
 
   return React.createClass({

--- a/test/support/stubRouterContext.react.js
+++ b/test/support/stubRouterContext.react.js
@@ -1,0 +1,30 @@
+import assign from 'object-assign'
+import React from 'react'
+
+export default (Component, props, stubs) => {
+  // function RouterStub() { }
+
+  var RouterStub = assign(
+    {
+      createHref() {},
+      getCurrentParams () {},
+      getCurrentPath () {},
+      getCurrentPathname () {},
+      getCurrentQuery () {},
+      getCurrentRoutes () {},
+      goBack () {},
+      isActive () {},
+      makePath () {},
+      push () {},
+      replace () {}
+    },
+    stubs  // Pass additional empty functions as necessary
+  )
+
+  return React.createClass({
+    childContextTypes: {router: React.PropTypes.func},
+    getChildContext () { return {router: RouterStub} },
+
+    render () { return <Component {...this.props} /> }
+  })
+}


### PR DESCRIPTION
@BJK @maneeshnycda @whabib @andela-tkomolafe @andela-aadepoju @andela-kadeniyi  Please review. This moves the `stubRouterContext` and `Container` over as prep for updating `BindToStores`
