### PR TITLE
Blr/statham/kill fetch method

### DIFF
--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -15,12 +15,8 @@ function ensureDataIsObject(data) {
 }
 
 var jsonStatham = {
-  setAdaptor(adaptor) {
-    this.adaptor = adaptor
-  },
-  getAdaptor() {
-    return (this.adaptor ? this.adaptor : new defaultAdaptor())
-  },
+  setAdaptor(adaptor) { this.adaptor = adaptor },
+  getAdaptor() { return (this.adaptor ? this.adaptor : new defaultAdaptor()) },
   buildRequest(path, method, data, withCredentials) {
     var headers = {} // TODO grab special header
     var adaptor = this.getAdaptor()
@@ -53,18 +49,10 @@ var jsonStatham = {
 
     return promise
   },
-  get(url, withCredentials) {
-    return this.sendRequest(this.buildRequest(url, 'GET', null, withCredentials))
-  },
-  put(url, data) {
-    return this.sendRequest(this.buildRequest(url, 'PUT', data))
-  },
-  post(url, data, withCredentials) {
-    return this.sendRequest(this.buildRequest(url, 'POST', data, withCredentials))
-  },
-  delete(url, data, withCredentials) {
-    return this.sendRequest(this.buildRequest(url, 'DELETE', data, withCredentials))
-  },
+  get(url, withCredentials) { return this.sendRequest(this.buildRequest(url, 'GET', null, withCredentials)) },
+  put(url, data) { return this.sendRequest(this.buildRequest(url, 'PUT', data)) },
+  post(url, data, withCredentials) { return this.sendRequest(this.buildRequest(url, 'POST', data, withCredentials)) },
+  delete(url, data, withCredentials) { return this.sendRequest(this.buildRequest(url, 'DELETE', data, withCredentials)) },
   postFile(url, data) {
     // Taken from: http://stackoverflow.com/questions/12431760/html5-formdata-file-upload-with-rubyonrails
     // and http://stackoverflow.com/questions/21234106/upload-file-using-reactjs-via-blueimp-fileupload-jquery-plugin

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -53,9 +53,6 @@ var jsonStatham = {
 
     return promise
   },
-  fetch(url) { // temporary backwards compatibility
-    return this.get(url)
-  },
   get(url, withCredentials) {
     return this.sendRequest(this.buildRequest(url, 'GET', null, withCredentials))
   },

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -4,13 +4,16 @@ import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 describe('jsonStatham', function() {
   var listener
-  var server
-  var spy
+var spy
+const args = () => spy.getCall(0).args[0]
 
-  class testAdaptor extends AjaxAdaptorBase {
-    serverBase() { return 'http://test.com' }
-    pathRoot() { return '/api' }
-  }
+class TestAdaptor extends AjaxAdaptorBase {
+  pathRoot() { return '/api' }
+  serverBase() { return 'http://test.com' }
+}
+
+  var server
+
   jsonStatham.setAdaptor(new testAdaptor())
 
   beforeEach(function() {
@@ -21,9 +24,6 @@ describe('jsonStatham', function() {
     $.ajax.restore()
   })
 
-  function args() {
-    return spy.getCall(0).args[0]
-  }
 
   describe('mechanics: ', function() {
     it('builds get request', function() {

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -3,7 +3,6 @@ import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 describe('jsonStatham', function() {
-  var listener
 var spy
 const args = () => spy.getCall(0).args[0]
 

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -2,10 +2,6 @@ import utils from '../../test/support/TestUtils'
 import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
-
-var spy
-const getArgumentsPassedToSpy = () => spy.getCall(0).args[0]
-
 class TestAdaptor extends AjaxAdaptorBase {
   pathRoot() { return '/api' }
   serverBase() { return 'http://test.com' }
@@ -13,6 +9,8 @@ class TestAdaptor extends AjaxAdaptorBase {
 
 describe('jsonStatham', () => {
   var server
+  var spy
+  const getArgumentsPassedToSpy = () => spy.getCall(0).args[0]
 
   before(() => jsonStatham.setAdaptor(new TestAdaptor()))
 

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -4,7 +4,7 @@ import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 
 var spy
-const args = () => spy.getCall(0).args[0]
+const getArgumentsPassedToSpy = () => spy.getCall(0).args[0]
 
 class TestAdaptor extends AjaxAdaptorBase {
   pathRoot() { return '/api' }
@@ -28,28 +28,28 @@ describe('jsonStatham', () => {
   describe('mechanics: ', () => {
     it('builds get request', () => {
       jsonStatham.get('/bla')
-      expect(args().url).to.equal('http://test.com/api/bla')
+      expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
     })
 
     it('builds PUT request', () => {
       jsonStatham.put('/bla', {param: 'some data'})
-      expect(args().url).to.equal('http://test.com/api/bla')
-      expect(args().method).to.equal('PUT')
-      expect(args().data.param).to.equal('some data')
+      expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
+      expect(getArgumentsPassedToSpy().method).to.equal('PUT')
+      expect(getArgumentsPassedToSpy().data.param).to.equal('some data')
     })
 
     it('builds POST request', () => {
       jsonStatham.post('/bla', {param: 'some data'})
-      expect(args().url).to.equal('http://test.com/api/bla')
-      expect(args().method).to.equal('POST')
-      expect(args().data.param).to.equal('some data')
+      expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
+      expect(getArgumentsPassedToSpy().method).to.equal('POST')
+      expect(getArgumentsPassedToSpy().data.param).to.equal('some data')
     })
 
     it('builds delete request', () => {
       jsonStatham.delete('/bla', {param: 'some data'})
-      expect(args().url).to.equal('http://test.com/api/bla')
-      expect(args().method).to.equal('DELETE')
-      expect(args().data.param).to.equal('some data')
+      expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
+      expect(getArgumentsPassedToSpy().method).to.equal('DELETE')
+      expect(getArgumentsPassedToSpy().data.param).to.equal('some data')
     })
 
     it('sets auth credentials', () => {
@@ -62,7 +62,7 @@ describe('jsonStatham', () => {
 
     it('sends post with auth credentials', () => {
       jsonStatham.post('/bla', {email: 'dude@dude.com'}, true)
-      expect(args().xhrFields.withCredentials).to.equal(true)
+      expect(getArgumentsPassedToSpy().xhrFields.withCredentials).to.equal(true)
     })
   })
 

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -17,10 +17,12 @@ class TestAdaptor extends AjaxAdaptorBase {
 
   beforeEach(function() {
     spy = sinon.spy($, 'ajax')
+    server = sinon.fakeServer.create()
   })
 
   afterEach(function() {
     $.ajax.restore()
+    server.restore()
   })
 
 
@@ -66,13 +68,6 @@ class TestAdaptor extends AjaxAdaptorBase {
   })
 
   describe('requests: ', function () {
-    beforeEach(function() {
-      server = sinon.fakeServer.create()
-    })
-
-     afterEach(function() {
-      server.restore()
-    })
 
     it('GET json', function(done) {
       utils.createServerAndMock('GET', '/api/test', JSON.stringify({fun: 'times'}), server, 200)

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -87,7 +87,7 @@ describe('jsonStatham', () => {
 
     it('POST data with error', done => {
       utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
-      jsonStatham.post('/test').done(() => null).fail(data => {
+      jsonStatham.post('/test').done(function() {}).fail(data => {
         expect(data.error.message).to.equal('oops')
         done()
       })

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -2,7 +2,7 @@ import utils from '../../test/support/TestUtils'
 import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
-describe('jsonStatham', function() {
+
 var spy
 const args = () => spy.getCall(0).args[0]
 
@@ -11,105 +11,103 @@ class TestAdaptor extends AjaxAdaptorBase {
   serverBase() { return 'http://test.com' }
 }
 
+describe('jsonStatham', () => {
   var server
 
-  jsonStatham.setAdaptor(new testAdaptor())
+  before(() => jsonStatham.setAdaptor(new TestAdaptor()))
 
-  beforeEach(function() {
+  beforeEach(() => {
     spy = sinon.spy($, 'ajax')
     server = sinon.fakeServer.create()
   })
-
-  afterEach(function() {
+  afterEach(() => {
     $.ajax.restore()
     server.restore()
   })
 
-
-  describe('mechanics: ', function() {
-    it('builds get request', function() {
+  describe('mechanics: ', () => {
+    it('builds get request', () => {
       jsonStatham.get('/bla')
       expect(args().url).to.equal('http://test.com/api/bla')
     })
 
-    it('builds PUT request', function() {
+    it('builds PUT request', () => {
       jsonStatham.put('/bla', {param: 'some data'})
       expect(args().url).to.equal('http://test.com/api/bla')
       expect(args().method).to.equal('PUT')
       expect(args().data.param).to.equal('some data')
     })
 
-    it('builds POST request', function() {
+    it('builds POST request', () => {
       jsonStatham.post('/bla', {param: 'some data'})
       expect(args().url).to.equal('http://test.com/api/bla')
       expect(args().method).to.equal('POST')
       expect(args().data.param).to.equal('some data')
     })
 
-    it('builds delete request', function() {
+    it('builds delete request', () => {
       jsonStatham.delete('/bla', {param: 'some data'})
       expect(args().url).to.equal('http://test.com/api/bla')
       expect(args().method).to.equal('DELETE')
       expect(args().data.param).to.equal('some data')
     })
 
-    it('sets auth credentials', function() {
+    it('sets auth credentials', () => {
       expect(jsonStatham.buildRequest('/bla', null, {}, true).xhrFields.withCredentials).to.equal(true)
     })
 
-    it('does not set auth credentials', function() {
+    it('does not set auth credentials', () => {
       expect(jsonStatham.buildRequest('/bla').xhrFields).to.equal(undefined)
     })
 
-    it('sends post with auth credentials', function() {
+    it('sends post with auth credentials', () => {
       jsonStatham.post('/bla', {email: 'dude@dude.com'}, true)
       expect(args().xhrFields.withCredentials).to.equal(true)
     })
   })
 
-  describe('requests: ', function () {
-
-    it('GET json', function(done) {
+  describe('requests: ', () => {
+    it('GET json', done => {
       utils.createServerAndMock('GET', '/api/test', JSON.stringify({fun: 'times'}), server, 200)
 
-      jsonStatham.fetch('/test').done(function(data) {
+      jsonStatham.get('/test').done(data => {
         expect(data.fun).to.equal('times')
         done()
       })
     })
 
-    it('POST data', function(done) {
+    it('POST data', done => {
       utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
 
-      jsonStatham.post('/test').done(function(data) {
+      jsonStatham.post('/test').done(data => {
         expect(data.fun).to.equal('times for post')
         done()
       })
     })
 
-    it('POST data with error', function(done) {
+    it('POST data with error', done => {
       utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
-      jsonStatham.post('/test').done(function() {}).fail(function(data) {
+      jsonStatham.post('/test').done(() => null).fail(data => {
         expect(data.error.message).to.equal('oops')
         done()
       })
     })
 
-    it('POST file', function(done) {
+    it('POST file', done => {
       utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
       var formData = new FormData()
       formData.append('comments', 'hey there', 'stuff')
-      jsonStatham.postFile('/test').done(function(data) {
+      jsonStatham.postFile('/test').done(data => {
         expect(data.fun).to.equal('times for post')
         done()
       })
     })
 
-    it ('POST file with error', function(done) {
+    it('POST file with error', done => {
       utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
       var formData = new FormData()
       formData.append('comments', 'hey there', 'stuff')
-      jsonStatham.postFile('/test', formData).fail(function(data) {
+      jsonStatham.postFile('/test', formData).fail(data => {
         expect(data.error.message).to.equal('oops')
         done()
       })


### PR DESCRIPTION
@everplans/fluxxed_up Please review. This removes the `fetch` method from `jsonStatham`, as I have a PR up on `web-apps` right now that removes all use of `fetcher.fetch`. I all cleaned up the test file since it was in ugly shape.
