### PR TITLE
Blr/statham/use adaptor headers

### DIFF
--- a/src/lib/AjaxAdaptorBase.js
+++ b/src/lib/AjaxAdaptorBase.js
@@ -1,8 +1,5 @@
-import assign from 'object-assign'
-
 export default class AjaxAdaptorBase {
   serverBase() { return '' } // default will use the relative path
   pathRoot() { return '/' }
   defaultHeaders() { return {} } // any headers that should be in every ajax request
-  headers(additionalHeaders) { return assign(this.defaultHeaders(), additionalHeaders) }  // Add other headers or overwrite defaults.
 }

--- a/src/lib/AjaxAdaptorBase.js
+++ b/src/lib/AjaxAdaptorBase.js
@@ -1,5 +1,5 @@
 export default class AjaxAdaptorBase {
   serverBase() { return '' } // default will use the relative path
   pathRoot() { return '/' }
-  defaultHeaders() { return {} } // any headers that should be in every ajax request
+  headers() { return {} } // any headers that should be in every ajax request
 }

--- a/src/lib/AjaxAdaptorBase.js
+++ b/src/lib/AjaxAdaptorBase.js
@@ -1,5 +1,5 @@
 export default class AjaxAdaptorBase {
   serverBase() { return '' } // default will use the relative path
   pathRoot() { return '/' }
-  headers() { return {} } // any headers that should be in every ajax request
+  defaultHeaders() { return {} } // any headers that should be in every ajax request
 }

--- a/src/lib/AjaxAdaptorBase.js
+++ b/src/lib/AjaxAdaptorBase.js
@@ -1,5 +1,8 @@
+import assign from 'object-assign'
+
 export default class AjaxAdaptorBase {
   serverBase() { return '' } // default will use the relative path
   pathRoot() { return '/' }
   defaultHeaders() { return {} } // any headers that should be in every ajax request
+  headers(additionalHeaders) { return assign(this.defaultHeaders(), additionalHeaders) }  // Add other headers or overwrite defaults.
 }

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -18,10 +18,9 @@ var jsonStatham = {
   setAdaptor(adaptor) { this.adaptor = adaptor },
   getAdaptor() { return (this.adaptor ? this.adaptor : new defaultAdaptor()) },
   buildRequest(path, method, data, withCredentials) {
-    var headers = {} // TODO grab special header
     var adaptor = this.getAdaptor()
     var opts = {
-      headers,
+      headers: adaptor.headers(),
       url: adaptor.serverBase() + cleanSlashes(adaptor.pathRoot()) + cleanSlashes(path)
     }
     if (method)

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -20,7 +20,7 @@ var jsonStatham = {
   buildRequest(path, method, data, withCredentials) {
     var adaptor = this.getAdaptor()
     var opts = {
-      headers: adaptor.headers(),
+      headers: adaptor.defaultHeaders(),
       url: adaptor.serverBase() + cleanSlashes(adaptor.pathRoot()) + cleanSlashes(path)
     }
     if (method)

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -1,4 +1,5 @@
 var jQuery = (typeof $ !== 'undefined') ? $ : require('jquery') // funny little hack, sometimes it's in the global scope, sometimes it's maybe not...
+import assign from 'object-assign'
 import defaultAdaptor from './AjaxAdaptorBase'
 
 function cleanSlashes(path) {
@@ -20,7 +21,7 @@ var jsonStatham = {
   buildRequest(path, method, data, withCredentials, additionalHeaders) {
     var adaptor = this.getAdaptor()
     var opts = {
-      headers: adaptor.headers(additionalHeaders),
+      headers: assign(adaptor.defaultHeaders(), additionalHeaders),
       url: adaptor.serverBase() + cleanSlashes(adaptor.pathRoot()) + cleanSlashes(path)
     }
     if (method)

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -17,10 +17,10 @@ function ensureDataIsObject(data) {
 var jsonStatham = {
   setAdaptor(adaptor) { this.adaptor = adaptor },
   getAdaptor() { return (this.adaptor ? this.adaptor : new defaultAdaptor()) },
-  buildRequest(path, method, data, withCredentials) {
+  buildRequest(path, method, data, withCredentials, additionalHeaders) {
     var adaptor = this.getAdaptor()
     var opts = {
-      headers: adaptor.defaultHeaders(),
+      headers: adaptor.headers(additionalHeaders),
       url: adaptor.serverBase() + cleanSlashes(adaptor.pathRoot()) + cleanSlashes(path)
     }
     if (method)

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -1,9 +1,11 @@
+import assign from 'object-assign'
 import utils from '../../test/support/TestUtils'
 import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 class TestAdaptor extends AjaxAdaptorBase {
   defaultHeaders() { return {yuri: 'orlov'} }
+  headers(additionalHeaders) { return assign(this.defaultHeaders(), additionalHeaders) }
   pathRoot() { return '/api' }
   serverBase() { return 'http://test.com' }
 }
@@ -63,10 +65,22 @@ describe('jsonStatham', () => {
       jsonStatham.post('/bla', {email: 'dude@dude.com'}, true)
       expect(getArgumentsPassedToSpy().xhrFields.withCredentials).to.equal(true)
     })
+  })
 
-    it('includes headers from the adaptor', () => {
-      jsonStatham.get('/bla')
-      expect(getArgumentsPassedToSpy().headers.yuri).to.equal('orlov')
+  describe('Headers:', () => {
+    it('includes default headers from the adaptor', () => {
+      const opts = jsonStatham.buildRequest('/bla', 'get', {}, false)  // Note: no need to pass additionalHeaders at all.
+      expect(opts.headers.yuri).to.equal('orlov')
+    })
+
+    it('adds additional headers passed to it', () => {
+      const opts = jsonStatham.buildRequest('/bla', 'get', {}, false, {stanley: 'goodspeed'})
+      expect(opts.headers.stanley).to.equal('goodspeed')
+    })
+
+    it('overwrites default headers with the same key', () => {
+      const opts = jsonStatham.buildRequest('/bla', 'get', {}, false, {yuri: 'goodspeed'})
+      expect(opts.headers.yuri).to.equal('goodspeed')
     })
   })
 

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -1,11 +1,9 @@
-import assign from 'object-assign'
 import utils from '../../test/support/TestUtils'
 import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 class TestAdaptor extends AjaxAdaptorBase {
   defaultHeaders() { return {yuri: 'orlov'} }
-  headers(additionalHeaders) { return assign(this.defaultHeaders(), additionalHeaders) }
   pathRoot() { return '/api' }
   serverBase() { return 'http://test.com' }
 }

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -3,7 +3,7 @@ import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 class TestAdaptor extends AjaxAdaptorBase {
-  headers() { return {yuri: 'orlov'} }
+  defaultHeaders() { return {yuri: 'orlov'} }
   pathRoot() { return '/api' }
   serverBase() { return 'http://test.com' }
 }

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -3,6 +3,7 @@ import jsonStatham from'../../src/lib/jsonStatham'
 import AjaxAdaptorBase from '../../src/lib/AjaxAdaptorBase'
 
 class TestAdaptor extends AjaxAdaptorBase {
+  headers() { return {yuri: 'orlov'} }
   pathRoot() { return '/api' }
   serverBase() { return 'http://test.com' }
 }
@@ -61,6 +62,11 @@ describe('jsonStatham', () => {
     it('sends post with auth credentials', () => {
       jsonStatham.post('/bla', {email: 'dude@dude.com'}, true)
       expect(getArgumentsPassedToSpy().xhrFields.withCredentials).to.equal(true)
+    })
+
+    it('includes headers from the adaptor', () => {
+      jsonStatham.get('/bla')
+      expect(getArgumentsPassedToSpy().headers.yuri).to.equal('orlov')
     })
   })
 


### PR DESCRIPTION
@everplans/fluxxed_up Please review. This PR tells `jsonStatham` to use the `headers` method on the `adaptor` it is told to use to set all request headers. I included a test that the headers are being set as part of the request `opts`.
