### PR TITLE
Simplify import paths that yoyo-ed to parent

### DIFF
--- a/src/lib/ActionPrototype.js
+++ b/src/lib/ActionPrototype.js
@@ -1,5 +1,5 @@
-import jsonStatham from '../lib/jsonStatham'
-import AppDispatcher from '../lib/fu-dispatcher'
+import jsonStatham from './jsonStatham'
+import AppDispatcher from './fu-dispatcher'
 import KeyMirror from 'keymirror'
 
 // TODOS:

--- a/src/lib/BindToStores.react.js
+++ b/src/lib/BindToStores.react.js
@@ -1,7 +1,7 @@
 import invariant from 'invariant'
 import React from 'react'
 
-import Container from '../lib/Container'
+import Container from './Container'
 import storePrototype from './StorePrototype'
 
 export default function bindResources(Component, resources, onBoundUpdate = null, resourceId = null) {

--- a/src/lib/StorePrototype.js
+++ b/src/lib/StorePrototype.js
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events'
 import assign from 'object-assign'
-import AppDispatcher from '../lib/fu-dispatcher'
+import AppDispatcher from './fu-dispatcher'
 
 // This factory method will return a fully-baked store. The following options are all optional:
   // * registerAction: this is an action type to auto-register with the app dispatcher. The callback will be the


### PR DESCRIPTION
@BJK Please review. This just kills some unnecessary complications in the import paths. Basically some imports went up a directory only to come right back into the current directory.
