### PR TITLE
Replace CodeClimate badge because I changed CC to watch on dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Fluxxed_up
 ===========
 
 [![Build Status](https://travis-ci.org/everplans/fluxxed_up.svg?branch=master)](https://travis-ci.org/everplans/fluxxed_up)
-[![Code Climate](https://codeclimate.com/repos/5735f40801a23449b30047d8/badges/3547178bd14ad420ae89/gpa.svg)](https://codeclimate.com/repos/5735f40801a23449b30047d8/feed)
+[![Code Climate](https://codeclimate.com/repos/57361f9378bbd61943002b6b/badges/59cae8b81ec09ab798fb/gpa.svg)](https://codeclimate.com/repos/57361f9378bbd61943002b6b/feed)
 [![Dependency Status](https://gemnasium.com/badges/github.com/everplans/fluxxed_up.svg)](https://gemnasium.com/github.com/everplans/fluxxed_up)
 
 Fluxxed_up is a React.js & Flux utility belt that handles simple patterns around the unidirectional dataflow. It is of medium opinionation: you write less boilerplate and get to focus on the code specific to your application. That said, it will let you write as much code 'by hand' as you want.


### PR DESCRIPTION
Minor...just had to update the badge because the old one pointed to the no longer existent master branch check. Since we are doing all the work on dev, we should have codeclimate review all code as it goes to dev.
