### PR TITLE
Use ReactDOM and correct indentation

### DIFF
--- a/test/support/ComponentHelpers.js
+++ b/test/support/ComponentHelpers.js
@@ -1,20 +1,18 @@
-import React from  'react'
+import ReactDOM from  'react-dom'
 
+export function bla() {}
 
-
-  export function bla() {}
-
-  export class TestContext {
-    constructor(component, done) {
-      this.component = component
-      this.done
-    }
-    render() {
-      this.div = document.createElement('div');
-      this.node = React.render(this.component, this.div, this.renderCallback.bind(this))
-      return this.node
-    }
-    renderCallback() {
-      this.done()
-    }
+export class TestContext {
+  constructor(component, done) {
+    this.component = component
+    this.done
   }
+  render() {
+    this.div = document.createElement('div');
+    this.node = ReactDOM.render(this.component, this.div, this.renderCallback.bind(this))
+    return this.node
+  }
+  renderCallback() {
+    this.done()
+  }
+}


### PR DESCRIPTION
@BJK @maneeshanand Please review. To prep for React v15 I just killed the one remaining instance of `React.render` and switched it to `ReactDOM.render`. The indentation was way off in the same file, so I fixed it up
