### PR TITLE
Ka/bug/make links and buttons accept single quotes

### DIFF
--- a/src/testUtils/TestRig.react.js
+++ b/src/testUtils/TestRig.react.js
@@ -44,11 +44,11 @@ export default class TestRig {
   }
   finish() { this.component.triggerFinalRender() }
   clickButton(buttonText) {
-    var element = this.domNode.find(`button:contains('${buttonText}')`)[0]
+    var element = this.domNode.find(`button:contains("${buttonText}")`)[0]
     this.clickElement(element)
   }
   clickLink(label) {
-    var element = this.domNode.find(`a:contains('${label}')`)[0]
+    var element = this.domNode.find(`a:contains("${label}")`)[0]
     this.clickElement(element)
   }
   // In the event of a gnarly css selector, just pass the element:


### PR DESCRIPTION
While working I discovered that any button or link that has a single quote (e.g `Don't grant any permissions`), `TestRig` breaks.

This PR changes single quotes to double quotes.

@whabib @BJK @maneeshanand @bartriordan Please review
