### PR TITLE
Add .call to jsonStatham call

### DIFF
--- a/src/lib/ActionPrototype.js
+++ b/src/lib/ActionPrototype.js
@@ -31,7 +31,7 @@ var ActionPrototype = {
   fireApi(method, url, data, options) {
     // set default values
     var errorAction = options.errorAction ? options.errorAction : options.successAction
-    jsonStatham[method](jsonStatham, url, data)
+    jsonStatham[method].call(jsonStatham, url, data)
       .then(successData => {
         if (options.successAction) {
           AppDispatcher.dispatch({


### PR DESCRIPTION
@BJK ran into this when trying to set up an app with the react boilerplate. Without .call it was messing up the order of arguments being passed through to the jsonStatham call. It also works without the .call and minus the 'JsonStatham' in the arguments list
