### PR TITLE
Blr/chores/add patch method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Right now, until we get some gulp scripts in place make sure to run the followin
 * `npm run build`
 * `npm run build-min`
 
-## Using: 
-* If you are using fluxxed_up from source, you'll need to have babel setup in your project, since the non-built code only exposes an es6 entry point. If you'd don't have babel, you'll need to run `npm run build` everytime you want to see your changes. 
+## Using:
+* If you are using fluxxed_up from source, you'll need to have babel setup in your project, since the non-built code only exposes an es6 entry point. If you'd don't have babel, you'll need to run `npm run build` everytime you want to see your changes.
 
-## What's included: 
+## What's included:
 
 * Action Prototype
 Based of off facebook patterns and intended to be used with flux. It works with a loose $.ajax wrapper to fire
 API calls to your server. It supplies a `fireApi` function to the action, so that you can use it when you define your
-own actions. You specific a REST actions (get, post, etc), and endpoint, and optional data payload (for a put or a post). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to use:
+own actions. You specific a REST actions (`GET`, `POST`, etc), and endpoint, and optional data payload (for a `PATCH`, `POST`, or `PUT`). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to use:
 
 ```
 //in MyActions.js
@@ -35,8 +35,8 @@ var TestAction = assign(ActionPrototype, {
   }),
   fetchUsers: function() {
      this.fireApi('get', 'assessment', null,
-      {successAction: this.Types.GOT_ASK_DOCUMENT_GROUPS, //Note that since no failureAction was specified, it will dispatch this action always. 
-      JSONHead: 'assessment'}) //head of the json coming back from the server. 
+      {successAction: this.Types.GOT_ASK_DOCUMENT_GROUPS, //Note that since no failureAction was specified, it will dispatch this action always.
+      JSONHead: 'assessment'}) //head of the json coming back from the server.
   }
 })
 ```

--- a/src/lib/jsonStatham.js
+++ b/src/lib/jsonStatham.js
@@ -58,6 +58,7 @@ var jsonStatham = {
     return promise
   },
   get(url) { return this.sendRequest(this.buildRequest(url, 'GET', null)) },
+  patch(url, data) { return this.sendRequest(this.buildRequest(url, 'PATCH', data)) },
   put(url, data) { return this.sendRequest(this.buildRequest(url, 'PUT', data)) },
   post(url, data) { return this.sendRequest(this.buildRequest(url, 'POST', data)) },
   delete(url, data) { return this.sendRequest(this.buildRequest(url, 'DELETE', data)) },

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -8,10 +8,11 @@ class TestAdaptor extends AjaxAdaptorBase {
   serverBase() { return 'http://test.com' }
 }
 
+let server
+let spy
+const getArgumentsPassedToSpy = () => spy.getCall(0).args[0]
+
 describe('jsonStatham', () => {
-  var server
-  var spy
-  const getArgumentsPassedToSpy = () => spy.getCall(0).args[0]
 
   before(() => jsonStatham.setAdaptor(new TestAdaptor()))
 
@@ -25,7 +26,7 @@ describe('jsonStatham', () => {
   })
 
   describe('mechanics: ', () => {
-    it('builds get request', () => {
+    it('builds GET request', () => {
       jsonStatham.get('/bla')
       expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
     })
@@ -57,7 +58,7 @@ describe('jsonStatham', () => {
       expect(spyData.data.param).to.equal('some data')
     })
 
-    it('builds delete request', () => {
+    it('builds DELETE request', () => {
       jsonStatham.delete('/bla', {param: 'some data'})
       const spyData = getArgumentsPassedToSpy()
       expect(spyData.url).to.equal('http://test.com/api/bla')
@@ -99,49 +100,51 @@ describe('jsonStatham', () => {
       })
     })
 
-    it('POST data', done => {
-      utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
-
-      jsonStatham.post('/test').done(data => {
-        expect(data.fun).to.equal('times for post')
-        done()
-      })
-    })
-
-    it('POST data with error', done => {
-      utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
-      jsonStatham.post('/test').done(function() {}).fail(data => {
-        expect(data.error.message).to.equal('oops')
-        done()
-      })
-    })
-
-    it('POST file', done => {
-      utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
-      var formData = new FormData()
-      formData.append('comments', 'hey there', 'stuff')
-      jsonStatham.postFile('/test').done(data => {
-        expect(data.fun).to.equal('times for post')
-        done()
-      })
-    })
-
-    it('POST file with error', done => {
-      utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
-      var formData = new FormData()
-      formData.append('comments', 'hey there', 'stuff')
-      jsonStatham.postFile('/test', formData).fail(data => {
-        expect(data.error.message).to.equal('oops')
-        done()
-      })
-    })
-
     it('does not attempt to parse whitespace-only strings as JSON', done => {
       const whitespaceOnly = '   '
       utils.createServerAndMock('GET', '/api/test', whitespaceOnly, server, 200)
       jsonStatham.get('/test').done(data => {
         expect(data).to.equal(whitespaceOnly)
         done()
+      })
+    })
+
+    describe('POST:', () => {
+      it('POST data', done => {
+        utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
+
+        jsonStatham.post('/test').done(data => {
+          expect(data.fun).to.equal('times for post')
+          done()
+        })
+      })
+
+      it('POST data with error', done => {
+        utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
+        jsonStatham.post('/test').done(function() {}).fail(data => {
+          expect(data.error.message).to.equal('oops')
+          done()
+        })
+      })
+
+      it('POST file', done => {
+        utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
+        var formData = new FormData()
+        formData.append('comments', 'hey there', 'stuff')
+        jsonStatham.postFile('/test').done(data => {
+          expect(data.fun).to.equal('times for post')
+          done()
+        })
+      })
+
+      it('POST file with error', done => {
+        utils.createServerAndMock('POST', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
+        var formData = new FormData()
+        formData.append('comments', 'hey there', 'stuff')
+        jsonStatham.postFile('/test', formData).fail(data => {
+          expect(data.error.message).to.equal('oops')
+          done()
+        })
       })
     })
   })

--- a/test/lib/jsonStathamSpec.js
+++ b/test/lib/jsonStathamSpec.js
@@ -31,6 +31,14 @@ describe('jsonStatham', () => {
       expect(getArgumentsPassedToSpy().url).to.equal('http://test.com/api/bla')
     })
 
+    it('builds PATCH request', () => {
+      jsonStatham.patch('/bla', {param: 'some data'})
+      const spyData = getArgumentsPassedToSpy()
+      expect(spyData.url).to.equal('http://test.com/api/bla')
+      expect(spyData.method).to.equal('PATCH')
+      expect(JSON.parse(spyData.data).param).to.equal('some data')
+    })
+
     it('builds PUT request', () => {
       jsonStatham.put('/bla', {param: 'some data'})
       const spyData = getArgumentsPassedToSpy()
@@ -109,6 +117,25 @@ describe('jsonStatham', () => {
       })
     })
 
+    describe('PATCH:', () => {
+      it('PATCH data', done => {
+        utils.createServerAndMock('PATCH', '/api/test', JSON.stringify({fun: 'times for patch'}), server, 200)
+
+        jsonStatham.patch('/test').done(data => {
+          expect(data.fun).to.equal('times for patch')
+          done()
+        })
+      })
+
+      it('PATCH data with error', done => {
+        utils.createServerAndMock('PATCH', '/api/test', JSON.stringify({error: {message: 'oops'}}), server, 422)
+        jsonStatham.patch('/test').done(function() {}).fail(data => {
+          expect(data.error.message).to.equal('oops')
+          done()
+        })
+      })
+    })
+
     describe('POST:', () => {
       it('POST data', done => {
         utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
@@ -126,7 +153,9 @@ describe('jsonStatham', () => {
           done()
         })
       })
+    })
 
+    describe('POST file:', () => {
       it('POST file', done => {
         utils.createServerAndMock('POST', '/api/test', JSON.stringify({fun: 'times for post'}), server, 200)
         var formData = new FormData()


### PR DESCRIPTION
@BJK @maneeshanand Please review. This PR adds `PATCH` functionality to `jsonStatham` since `PUT` is really only for replacing a whole object while `PATCH` is for updating an existing object.