### PR TITLE
Blr/chores/clean readme and minor lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ Fluxxed_up [![Build Status](https://travis-ci.org/everplans/fluxxed_up.svg?branc
 - [Releasing](#releasing)
 - [Build Process](#build-process)
 - [What's Included](#whats-included)
+  - [Action Prototype](#actionprototype)
+  - [Dispatcher](#dispatcher)
+  - [ExtraStorage](#extrastorage)
+  - [FeatureFlags](#featureflags)
+  - [jsonStatham](#jsonstatham)
 
 Fluxxed_up is a React.js and Flux utility belt that handles simple patterns around the unidirectional dataflow. It is of medium opinionation: you write less boilerplate and get to focus on the code specific to your application. That said, it will let you write as much code 'by hand' as you want.
 
@@ -21,9 +26,9 @@ Right now, until we get some gulp scripts in place make sure to run the followin
 ## Build Process
 If you are using fluxxed_up from source, you'll need to have Babel setup in your project since the unbuilt code only exposes an ES6 entry point. If you don't have Babel, you'll need to run `npm run build` every time you want to see your changes.
 
-## What's included
+## What's Included
 
-* Action Prototype
+##### ActionPrototype
 Based off of Facebook patterns and intended to be used with flux. It works with a loose $.ajax wrapper to fire
 API calls to your server. It supplies a `fireApi` function to the action, so that you can use it when you define your
 own actions. You specific a REST actions (`GET`, `POST`, etc), and endpoint, and optional data payload (for a `PATCH`, `POST`, or `PUT`). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to construct an action with `ActionPrototype`:
@@ -51,18 +56,18 @@ const AssessmentActions = assign(
 )
 ```
 
-* Dispatcher
+##### Dispatcher
 Lightweight wrapper around the flux dispatcher. It will throw an exception if you try to dispatch an action with an undefined type. (You'd be surprised how many bugs you pre-emptively avoid doing this.)
 
-* ExtraStorage
+##### ExtraStorage
 This is a little module that wraps default browser local storage behavior. It has a small wrapper to simulate behavior for when a browser is in incognito mode.
 
-* FeatureFlags
+##### FeatureFlags
 Helper class to query if a feature flag is on or off based on some JSON config. We fetch this from the server and turn on/off features for a user based on the config. A flag not specified in the config will auto default to disabled. Example:
 ```javascript
 FeatureFlags.init({[{flag:'new_thing', status: 'ENABLED'}]})
 FeatureFlags.isEnabled('new_thing') // true
 ```
 
-* jsonStatham
+##### jsonStatham
 Lightweight wrapper around jQuery's ajax functionality. It assumes a simple RESTful api on the server side. It will fire success/failure callbacks based on server response. It has some extra settings to specify API keys and other auth.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If you are using fluxxed_up from source, you'll need to have Babel setup in your
 
 ## What's Included
 
-##### ActionPrototype
+#### ActionPrototype
 Based off of Facebook patterns and intended to be used with flux. It works with a loose $.ajax wrapper to fire
 API calls to your server. It supplies a `fireApi` function to the action, so that you can use it when you define your
 own actions. You specific a REST actions (`GET`, `POST`, etc), and endpoint, and optional data payload (for a `PATCH`, `POST`, or `PUT`). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to construct an action with `ActionPrototype`:
@@ -56,18 +56,18 @@ const AssessmentActions = assign(
 )
 ```
 
-##### Dispatcher
+#### Dispatcher
 Lightweight wrapper around the flux dispatcher. It will throw an exception if you try to dispatch an action with an undefined type. (You'd be surprised how many bugs you pre-emptively avoid doing this.)
 
-##### ExtraStorage
+#### ExtraStorage
 This is a little module that wraps default browser local storage behavior. It has a small wrapper to simulate behavior for when a browser is in incognito mode.
 
-##### FeatureFlags
+#### FeatureFlags
 Helper class to query if a feature flag is on or off based on some JSON config. We fetch this from the server and turn on/off features for a user based on the config. A flag not specified in the config will auto default to disabled. Example:
 ```javascript
 FeatureFlags.init({[{flag:'new_thing', status: 'ENABLED'}]})
 FeatureFlags.isEnabled('new_thing') // true
 ```
 
-##### jsonStatham
+#### jsonStatham
 Lightweight wrapper around jQuery's ajax functionality. It assumes a simple RESTful api on the server side. It will fire success/failure callbacks based on server response. It has some extra settings to specify API keys and other auth.

--- a/README.md
+++ b/README.md
@@ -1,60 +1,68 @@
-Fluxxed_up
+Fluxxed_up [![Build Status](https://travis-ci.org/everplans/fluxxed_up.svg?branch=master)](https://travis-ci.org/everplans/fluxxed_up) [![Code Climate](https://codeclimate.com/repos/57361f9378bbd61943002b6b/badges/59cae8b81ec09ab798fb/gpa.svg)](https://codeclimate.com/repos/57361f9378bbd61943002b6b/feed) [![Dependency Status](https://gemnasium.com/badges/github.com/everplans/fluxxed_up.svg)](https://gemnasium.com/github.com/everplans/fluxxed_up)
 ===========
 
-[![Build Status](https://travis-ci.org/everplans/fluxxed_up.svg?branch=master)](https://travis-ci.org/everplans/fluxxed_up)
-[![Code Climate](https://codeclimate.com/repos/57361f9378bbd61943002b6b/badges/59cae8b81ec09ab798fb/gpa.svg)](https://codeclimate.com/repos/57361f9378bbd61943002b6b/feed)
-[![Dependency Status](https://gemnasium.com/badges/github.com/everplans/fluxxed_up.svg)](https://gemnasium.com/github.com/everplans/fluxxed_up)
+- [History](#history)
+- [Releasing](#releasing)
+- [Build Process](#build-process)
+- [What's Included](#whats-included)
 
-Fluxxed_up is a React.js & Flux utility belt that handles simple patterns around the unidirectional dataflow. It is of medium opinionation: you write less boilerplate and get to focus on the code specific to your application. That said, it will let you write as much code 'by hand' as you want.
+Fluxxed_up is a React.js and Flux utility belt that handles simple patterns around the unidirectional dataflow. It is of medium opinionation: you write less boilerplate and get to focus on the code specific to your application. That said, it will let you write as much code 'by hand' as you want.
 
 The goal of fluxxed_up is to keep most components as stateless as possible by wrapping them in 'controller' components that handle the asynchronous dataflow and share information with child components by passing `props`. The big win of this approach is that the non-controller components are ultimately more testable because they are deterministic and synchronous. In other words, the controller components handle the `state` and any asynchronous data requests so that the rest of the components are blissfully unaware of everything not included in the `props` passed to them.
 
 ## History
 This is a complete reboot of some earlier ideas that began in a Backbone app. If you look at the original commits you'll see it. We kept this repo as a reminder of our earlier folly. Who knows, maybe this won't be a React framework for long.
 
-## Releasing:
+## Releasing
 Right now, until we get some gulp scripts in place make sure to run the following before packaging and releasing a version:
 * `npm run build`
 * `npm run build-min`
 
-## Using:
-* If you are using fluxxed_up from source, you'll need to have babel setup in your project, since the non-built code only exposes an es6 entry point. If you'd don't have babel, you'll need to run `npm run build` everytime you want to see your changes.
+## Build Process
+If you are using fluxxed_up from source, you'll need to have Babel setup in your project since the unbuilt code only exposes an ES6 entry point. If you don't have Babel, you'll need to run `npm run build` every time you want to see your changes.
 
-## What's included:
+## What's included
 
 * Action Prototype
-Based of off facebook patterns and intended to be used with flux. It works with a loose $.ajax wrapper to fire
+Based off of Facebook patterns and intended to be used with flux. It works with a loose $.ajax wrapper to fire
 API calls to your server. It supplies a `fireApi` function to the action, so that you can use it when you define your
-own actions. You specific a REST actions (`GET`, `POST`, etc), and endpoint, and optional data payload (for a `PATCH`, `POST`, or `PUT`). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to use:
+own actions. You specific a REST actions (`GET`, `POST`, etc), and endpoint, and optional data payload (for a `PATCH`, `POST`, or `PUT`). You can optionally supply action types to dispatch based on a success or failure from the server. Here's an example of how to construct an action with `ActionPrototype`:
 
-```
-//in MyActions.js
-var TestAction = assign(ActionPrototype, {
-  Types: KeyMirror({
-    GOT_USERS: null
-  }),
-  fetchUsers: function() {
-     this.fireApi('get', 'assessment', null,
-      {successAction: this.Types.GOT_ASK_DOCUMENT_GROUPS, //Note that since no failureAction was specified, it will dispatch this action always.
-      JSONHead: 'assessment'}) //head of the json coming back from the server.
+```javascript
+// AssessmentActions.js
+const AssessmentActions = assign(
+  ActionPrototype,
+  {
+    Types: KeyMirror({
+      GOT_ASSESSMENT: null
+    }),
+    fetchUsers() {
+      this.fireApi(
+        'get',
+        'assessment',
+        null,
+        {
+          JSONHead: 'assessment', // Top-level key in the JSON returned by the server.
+          successAction: this.Types.GOT_ASSESSMENT // Note that since no failureAction was specified, it will always dispatch this action.
+        }
+      )
+    }
   }
-})
+)
 ```
 
 * Dispatcher
-Lightweight wrapper around the flux dispatcher. It will throw an exception if you try to dispatch an action with an undefined type. (You'd be surprised how many bugs you pre-emptively avoid doing this).
-
-* jsonStatham
-Lightweight wrapper around jQuery's ajax functionality. It assumes a simple RESTful api on the server side. It will fire success/failure callbacks based on server response. I has some extra settings to specific API keys and other auth.
-
-* FeatureFlags
-Little helper class to query if a feature flag is on or off based on some JSON config. We fetch this from the server and turn on/off features for a user based on the config. A flag not specified in the config will auto default to disabled. Example:
-```FeatureFlags.init({[{flag:'new_thing', status: 'ENABLED'}]})
-
-FeatureFlags.isEnabled('new_thing') //true
-```
+Lightweight wrapper around the flux dispatcher. It will throw an exception if you try to dispatch an action with an undefined type. (You'd be surprised how many bugs you pre-emptively avoid doing this.)
 
 * ExtraStorage
 This is a little module that wraps default browser local storage behavior. It has a small wrapper to simulate behavior for when a browser is in incognito mode.
 
+* FeatureFlags
+Helper class to query if a feature flag is on or off based on some JSON config. We fetch this from the server and turn on/off features for a user based on the config. A flag not specified in the config will auto default to disabled. Example:
+```javascript
+FeatureFlags.init({[{flag:'new_thing', status: 'ENABLED'}]})
+FeatureFlags.isEnabled('new_thing') // true
+```
 
+* jsonStatham
+Lightweight wrapper around jQuery's ajax functionality. It assumes a simple RESTful api on the server side. It will fire success/failure callbacks based on server response. It has some extra settings to specify API keys and other auth.

--- a/src/lib/FeatureFlags.js
+++ b/src/lib/FeatureFlags.js
@@ -1,7 +1,7 @@
 class FeatureFlags {
   init(flags) {
     this.flags = {}
-    flags.map((flagObject) => { this.flags[flagObject.flag] = flagObject.status })
+    flags.map(flagObject => { this.flags[flagObject.flag] = flagObject.status })
   }
   isEnabled(flagName) {
     return (this.flags && this.flags[flagName] ? String(this.flags[flagName]).toUpperCase() === 'ENABLED' : false)

--- a/src/lib/extra_storage.js
+++ b/src/lib/extra_storage.js
@@ -2,7 +2,7 @@
 var storage = {}
 
 var extra_storage = {
-  getItem: function(key) {
+  getItem(key) {
     try {
       window.sessionStorage.setItem('__extra_storage-flag__', 'test')
       return window.sessionStorage.getItem(key)
@@ -10,14 +10,14 @@ var extra_storage = {
       return storage[key]
     }
   },
-  setItem: function(key, value) {
+  setItem(key, value) {
     try {
       window.sessionStorage.setItem(key, value)
     } catch (error) {
       storage[key] = value
     }
   },
-  removeItem: function(key) {
+  removeItem(key) {
     try {
       return window.sessionStorage.removeItem(key)
     } catch (error) {

--- a/src/lib/fu-dispatcher.js
+++ b/src/lib/fu-dispatcher.js
@@ -3,7 +3,7 @@ import assign from 'object-assign'
 import invariant from 'invariant'
 
 var AppDispatcher = assign(new Dispatcher(), {
-  dispatch: function(action) {
+  dispatch(action) {
     invariant(action.actionType, 'action type is undefined.')
     Dispatcher.prototype.dispatch.call(this, action)
   }

--- a/src/testUtils/TestRig.react.js
+++ b/src/testUtils/TestRig.react.js
@@ -8,7 +8,7 @@ export class TestRigComponent extends React.Component {
     super(props)
     this.state = {keyVal: Math.random(), testComplete: false}
   }
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (this.state.testComplete === true)
       this.state.expectationCallback()
   }


### PR DESCRIPTION
@BJK @maneeshanand Please review. This PR:
- Cleans up the `README` by adding an anchor-linked list of sections, cleaning up grammar, cleaning up code layout, and adding JavaScript formatting for code blocks; and,
- Does some minor linting (e.g., use object method shorthand).