### PR TITLE
Bump Node version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: node_js
 node_js:
 - '6.9'
-install:
-- npm install
 cache:
+  yarn: true
   directories:
   - node_modules
   - bower_components
 notifications:
   slack:
     secure: hA801rSo3a/ECnlViPFBqiTG1NgS1sMEExNb/MG+cTipQCAZ0Wx8baeHCC28bjv+6VZFTIrDcrIBdfPXmbgrIPm3xgmQWuhO2jLzYofPU0xol8dczlxpxBvTKwqz7oniL3nXTOfBLn5wsh0cW+lOCd+w2s5wz5hjQyGrtuOwmFo=
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+- '6.9'
 install:
 - npm install
 cache:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "keymirror": "^0.1.1",
     "mocha": "^2.2.5",
     "object-assign": "^3.0.0",
-    "phantomjs": "^1.9.17",
+    "phantomjs": "^2.1.7",
     "react": "^0.14.2",
     "react-addons-test-utils": "^0.14.2",
     "react-dom": "^0.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,9 +2566,9 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-phantomjs@^1.9.17:
-  version "1.9.20"
-  resolved "https://registry.yarnpkg.com/phantomjs/-/phantomjs-1.9.20.tgz#4424aca20e14d255c0b0889af6f6b8973da10e0d"
+phantomjs@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/phantomjs/-/phantomjs-2.1.7.tgz#c6910f67935c37285b6114329fc2f27d5f3e3134"
   dependencies:
     extract-zip "~1.5.0"
     fs-extra "~0.26.4"


### PR DESCRIPTION
It's insane that this was still running in a Node v0.10.x environment. This PR fixes that.